### PR TITLE
Add ability to load different schema in TLSerializer and TLDeserializer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,28 @@ declare class MyAsyncLocalStorage {
   getItem(key: string): Promise<string|null>;
 }
 
+interface TlConstructor {
+  id: string
+  predicate: string
+  type: string
+}
+
+interface TlMethod {
+  id: string
+  method: string
+  type: string
+}
+
+interface TlSchema {
+  constructors: TlConstructor[]
+  methods: TlMethod[]
+}
+
+export interface Schema {
+  constructorsById: Record<string, TlConstructor>
+  methodsByName: Record<string, TlMethod>
+  constructorsIdsByPredicate: Record<string, number>
+}
 export class MTProto {
   constructor(options: {
     api_id: number,
@@ -40,3 +62,5 @@ export function getSRPParams(params: {
   A: Uint8Array,
   M1: Uint8Array
 }>
+
+export function getSchema(schema: TlSchema, existingSchema?: Schema | null): Promise<Schema>

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const { MTProto } = require('./src');
 const { getSRPParams } = require('./src/utils/crypto');
+const { getSchema } = require('./src/tl/schema');
 
-module.exports = { MTProto, getSRPParams };
+module.exports = { MTProto, getSRPParams, getSchema };

--- a/src/tl/deserializer/index.js
+++ b/src/tl/deserializer/index.js
@@ -4,7 +4,7 @@ const { intsToLong } = require('../../utils/common');
 
 class TLDeserializer {
   constructor(buffer, options = {}) {
-    const { predicatesHandlers = {} } = options;
+    const { predicatesHandlers = {}, schema = schema } = options;
 
     this.buffer = buffer;
     this.byteView = new Uint8Array(this.buffer);
@@ -17,6 +17,7 @@ class TLDeserializer {
     this.offset = 0;
 
     this.predicatesHandlers = predicatesHandlers;
+    this.schema = schema;
   }
 
   int() {
@@ -61,11 +62,11 @@ class TLDeserializer {
   bool() {
     const id = this.uint32();
 
-    if (id === schema.constructorsIdsByPredicate.boolTrue) {
+    if (id === this.schema.constructorsIdsByPredicate.boolTrue) {
       return true;
     }
 
-    if (id === schema.constructorsIdsByPredicate.boolFalse) {
+    if (id === this.schema.constructorsIdsByPredicate.boolFalse) {
       return false;
     }
 
@@ -149,7 +150,7 @@ class TLDeserializer {
       return result;
     }
 
-    const constructor = schema.constructorsById[constructorId];
+    const constructor = this.schema.constructorsById[constructorId];
 
     if (!constructor) {
       throw new Error(

--- a/src/tl/schema.js
+++ b/src/tl/schema.js
@@ -1,0 +1,41 @@
+function handleConstructors (schema, constructor) {
+  constructor.id = intToUint(constructor.id);
+
+  if (constructor.id in schema.constructorsById) {
+    console.warn(`TL schema constructor ID duplicate: ${constructor.id}`);
+  }
+
+  if (constructor.predicate in schema.constructorsIdsByPredicate) {
+    console.warn(`TL schema constructor predicate duplicate: ${constructor.predicate}`);
+  }
+
+  schema.constructorsById[constructor.id] = constructor;
+  schema.constructorsIdsByPredicate[constructor.predicate] = constructor.id;
+}
+
+function handleMethods (schema, method) {
+  method.id = intToUint(method.id);
+
+  if (method.method in schema.methodsByName) {
+    console.warn(`TL schema method duplicate: ${method.method}`);
+  }
+
+  schema.methodsByName[method.method] = method;
+}
+
+async function getSchema (schema, existingSchema = null) {
+  const result = existingSchema !== null
+    ? existingSchema
+    : {
+      constructorsById: {},
+      methodsByName: {},
+      constructorsIdsByPredicate: {},
+    };
+
+  schema.constructors.forEach(e => handleConstructors(result, e));
+  schema.methods.forEach(e => handleMethods(result, e));
+
+  return result;
+}
+
+module.exports = { getSchema };

--- a/src/tl/serializer/index.js
+++ b/src/tl/serializer/index.js
@@ -4,7 +4,9 @@ const { bigIntToBytes } = require('../../utils/common');
 
 class TLSerializer {
   constructor(options = {}) {
-    const { maxLength = 2048 } = options;
+    const { maxLength = 2048, schema = schema } = options;
+
+    this.schema = schema;
 
     this.maxLength = maxLength;
     this.offset = 0; // in bytes
@@ -57,7 +59,7 @@ class TLSerializer {
   }
 
   method(methodName, params) {
-    const methodData = schema.methodsByName[methodName];
+    const methodData = this.schema.methodsByName[methodName];
 
     if (!methodData) {
       throw new Error(`Method ${methodName} not found in schema`);
@@ -129,8 +131,8 @@ class TLSerializer {
       return;
     }
 
-    const constructorId = schema.constructorsIdsByPredicate[predicate._];
-    const constructorData = schema.constructorsById[constructorId];
+    const constructorId = this.schema.constructorsIdsByPredicate[predicate._];
+    const constructorData = this.schema.constructorsById[constructorId];
 
     if (!constructorData) {
       throw new Error(`Constructor ${predicate._} not found in schema`);


### PR DESCRIPTION
This will allow use of the library with different layers as well as future updates

More importantly, this enables use of the serializer/deserializer with secret chats that use end-to-end encryption and have a [different TL schema](https://core.telegram.org/schema/end-to-end) that differs from the main one.