### PR TITLE
Adding react-native environment

### DIFF
--- a/envs/react-native/get-local-storage.js
+++ b/envs/react-native/get-local-storage.js
@@ -1,0 +1,10 @@
+const { AsyncStorage } = require('react-native');
+
+function getLocalStorage() {
+  return {
+    set: AsyncStorage.setItem,
+    get: AsyncStorage.getItem
+  }
+}
+
+module.exports = getLocalStorage;

--- a/envs/react-native/get-random-bytes.js
+++ b/envs/react-native/get-random-bytes.js
@@ -1,0 +1,9 @@
+require('react-native-get-random-values');
+
+function getRandomBytes(length) {
+  const bytes = new Uint8Array(length);
+  crypto.getRandomValues(bytes);
+  return bytes;
+}
+
+module.exports = getRandomBytes;

--- a/envs/react-native/index.js
+++ b/envs/react-native/index.js
@@ -1,0 +1,27 @@
+const { polyfillGlobal } = require("react-native/Libraries/Utilities/PolyfillFunctions");
+const { TextEncoder, TextDecoder } = require("web-encoding");
+const makeMTProto = require('../../src');
+const SHA1 = require('./sha1');
+const SHA256 = require('./sha256');
+const PBKDF2 = require('./pbkdf2');
+const Transport = require('./transport');
+const getRandomBytes = require('./get-random-bytes');
+const getLocalStorage = require('./get-local-storage');
+
+polyfillGlobal("TextEncoder", () => TextEncoder);
+polyfillGlobal("TextDecoder", () => TextDecoder);
+
+function createTransport(dc, crypto) {
+  return new Transport(dc, crypto);
+}
+
+const MTProto = makeMTProto({
+  SHA1,
+  SHA256,
+  PBKDF2,
+  getRandomBytes,
+  getLocalStorage,
+  createTransport,
+});
+
+module.exports = MTProto;

--- a/envs/react-native/pbkdf2.js
+++ b/envs/react-native/pbkdf2.js
@@ -1,0 +1,7 @@
+const sha256 = require("fast-sha256");
+
+async function PBKDF2(password, salt, iterations) {
+  return sha256.pbkdf2(password, salt, iterations, 512);
+}
+
+module.exports = PBKDF2;

--- a/envs/react-native/sha1.js
+++ b/envs/react-native/sha1.js
@@ -1,0 +1,10 @@
+const jsSHA = require("jssha");
+
+async function SHA1(data) {
+  const format = data instanceof Uint8Array ? "UINT8ARRAY" : "ARRAYBUFFER";
+  const digest = new jsSHA("SHA-1", format)
+  digest.update(data)
+  return digest.getHash("UINT8ARRAY")
+}
+
+module.exports = SHA1;

--- a/envs/react-native/sha256.js
+++ b/envs/react-native/sha256.js
@@ -1,0 +1,10 @@
+const jsSHA = require("jssha");
+
+async function SHA256(data) {
+  const format = data instanceof Uint8Array ? "UINT8ARRAY" : "ARRAYBUFFER";
+  const digest = new jsSHA("SHA-256", format)
+  digest.update(data)
+  return digest.getHash("UINT8ARRAY")
+}
+
+module.exports = SHA256;

--- a/envs/react-native/transport.js
+++ b/envs/react-native/transport.js
@@ -1,0 +1,1 @@
+module.exports = require('../browser/transport');

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "/src"
   ],
   "main": "./envs/node/index.js",
+  "react-native": "./envs/react-native/index.js",
   "engines": {
     "node": ">=12"
   },
@@ -54,5 +55,12 @@
   "devDependencies": {
     "jest": "26.6.3",
     "npm-run-all": "4.1.5"
+  },
+  "peerDependencies": {
+    "react-native": "*",
+    "fast-sha256": "^1.3.0",
+    "jssha": "^3.2.0",
+    "react-native-get-random-values": "^1.7.0",
+    "web-encoding": "^1.1.5"
   }
 }


### PR DESCRIPTION
This adds a working react-native environment to mtproto-core. I was unable to get things working with the canonical [expo-crypto](https://docs.expo.io/versions/latest/sdk/crypto/) because it does not accept `Uint8Array`s as inputs to it's hashing methods, so I grabbed some off-the-shelf modules to polyfill all the required methods and built-ins.