### PR TITLE
Only subscribe to updates when a handler is attached.

### DIFF
--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -103,7 +103,7 @@ class RPC {
 
       const newListenerHandler = async (event) => {
         if (updatesEvents.includes(event)) {
-          this.context.off('newListener', newListenerHandler);
+          this.context.updates.off('newListener', newListenerHandler);
           try {
             // This request will subscribe the connection to updates from telegram's server.
             const state = await this.call('updates.getState');


### PR DESCRIPTION
This PR updates the RPC open transport method to only subscribe to telegram updates if an update handler is attached to the `context.updates` event emitter.

Per [Telegram's docs](https://core.telegram.org/api/files#general-considerations) for file transfers:

> It is recommended that large queries (upload.getFile, upload.saveFilePart, upload.getWebFile) be handled through a separate session and a separate connection, in which no methods other than these should be executed. If this is done, then data transfer will cause less interference with getting updates and other method calls.

Currently, `mtproto-core` automatically subscribes to updates when you create an instance of `MTProto`. By listening to the [`newListeners`](https://nodejs.org/dist/v11.13.0/docs/api/events.html#events_event_newlistener) handler on an EventEmitter, we can optionally subscribe to events only when the client cares about them. This will allow users to create two instances of the MTProto client -- one specifically for file transfers that does not listen for telegram updates, and another for everything else.