### PR TITLE
Fix "pako" import

### DIFF
--- a/src/tl/deserializer/index.js
+++ b/src/tl/deserializer/index.js
@@ -1,4 +1,4 @@
-const { inflate } = require('pako/lib/inflate.js');
+const { inflate } = require('pako');
 const parserMap = require('../parser');
 const { intsToLong } = require('../../utils/common');
 


### PR DESCRIPTION
The package doesn't work. If you replace this import, then everything will work again.
I was getting this error:
`Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/inflate.js' is not defined by "exports"`

We have already written about this error here:
https://www.gitmemory.com/issue/alik0211/mtproto-core/178/835937201
https://githubmemory.com/repo/alik0211/mtproto-core/issues/178