### PR TITLE
Auto tl build for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,6 @@
   },
   "author": "Ali Gasymov <alik0211alik@gmail.com> (https://gasymov.com/)",
   "repository": "github:alik0211/mtproto-core",
-  "files": [
-    "/envs",
-    "/src"
-  ],
   "main": "./envs/node/index.js",
   "engines": {
     "node": ">=12"
@@ -50,10 +46,10 @@
     "events": "3.3.0",
     "leemon": "6.2.0",
     "lodash.debounce": "4.0.8",
+    "npm-run-all": "4.1.5",
     "pako": "2.0.3"
   },
   "devDependencies": {
-    "jest": "26.6.3",
-    "npm-run-all": "4.1.5"
+    "jest": "26.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "generate-builder": "node scripts/generate-builder.js",
     "generate-parser": "node scripts/generate-parser.js",
     "generate-tl": "run-p generate-builder generate-parser",
+    "postinstall": "run-s generate-tl",
     "prepublishOnly": "run-s generate-tl"
   },
   "license": "GPL-3.0",


### PR DESCRIPTION
If build lib by npm (from github link) then do not build tl. NPM will run build scripts on postinstall event.