### PR TITLE
Add possibility to destroy (disconnect)

### DIFF
--- a/envs/browser/transport.js
+++ b/envs/browser/transport.js
@@ -17,18 +17,18 @@ class Transport extends Obfuscated {
       this.dc.test ? '/apiws_test' : '/apiws'
     }`;
     this.crypto = crypto;
-    this.destroyed = false
-    this.handleError = this.handleError.bind(this)
-    this.handleOpen = this.handleOpen.bind(this)
-    this.handleClose = this.handleClose.bind(this)
-    this.handleMessage = this.handleMessage.bind(this)
+    this.destroyed = false;
+    this.handleError = this.handleError.bind(this);
+    this.handleOpen = this.handleOpen.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+    this.handleMessage = this.handleMessage.bind(this);
 
     this.connect();
   }
 
   destroy() {
-    this.destroyed = true
-    this.ws.close()
+    this.destroyed = true;
+    this.ws.close();
   }
 
   get isAvailable() {
@@ -38,6 +38,7 @@ class Transport extends Obfuscated {
   connect() {
     this.socket = new WebSocket(this.url, 'binary');
     this.socket.binaryType = 'arraybuffer';
+
     this.socket.addEventListener('error', this.handleError);
     this.socket.addEventListener('open', this.handleOpen);
     this.socket.addEventListener('close', this.handleClose);

--- a/envs/browser/transport.js
+++ b/envs/browser/transport.js
@@ -62,13 +62,12 @@ class Transport extends Obfuscated {
       this.socket.close();
     }
 
-    if (this.destroyed) {
-      this.socket.removeEventListener('error', this.handleError);
-      this.socket.removeEventListener('open', this.handleOpen);
-      this.socket.removeEventListener('close', this.handleClose);
-      this.socket.removeEventListener('message', this.handleMessage);
-    }
-    else {
+    this.socket.removeEventListener('error', this.handleError);
+    this.socket.removeEventListener('open', this.handleOpen);
+    this.socket.removeEventListener('close', this.handleClose);
+    this.socket.removeEventListener('message', this.handleMessage);
+
+    if (!this.destroyed) {
       this.connect();
     }
   }

--- a/envs/browser/transport.js
+++ b/envs/browser/transport.js
@@ -13,8 +13,9 @@ class Transport extends Obfuscated {
     super();
 
     this.dc = dc;
-    this.url = `wss://${subdomainsMap[this.dc.id]}.web.telegram.org${this.dc.test ? '/apiws_test' : '/apiws'
-      }`;
+    this.url = `wss://${subdomainsMap[this.dc.id]}.web.telegram.org${
+      this.dc.test ? '/apiws_test' : '/apiws'
+    }`;
     this.crypto = crypto;
     this.destroyed = false
     this.handleError = this.handleError.bind(this)

--- a/envs/node/transport.js
+++ b/envs/node/transport.js
@@ -9,11 +9,11 @@ class Transport extends Obfuscated {
     this.dc = dc;
     this.debug = baseDebug.extend(`transport-${this.dc.id}`);
     this.crypto = crypto;
-    this.destroyed = false
-    this.handleConnect = this.handleConnect.bind(this)
-    this.handleData = this.handleData.bind(this)
-    this.handleError = this.handleError.bind(this)
-    this.handleClose = this.handleClose.bind(this)
+    this.destroyed = false;
+    this.handleConnect = this.handleConnect.bind(this);
+    this.handleData = this.handleData.bind(this);
+    this.handleError = this.handleError.bind(this);
+    this.handleClose = this.handleClose.bind(this);
 
     this.connect();
   }

--- a/envs/node/transport.js
+++ b/envs/node/transport.js
@@ -19,13 +19,12 @@ class Transport extends Obfuscated {
   }
 
   destroy() {
-    this.destroyed = true
-
-    if (!this.socket.destroyed) {
-      this.socket.destroy()
-    }
-
+    this.destroyed = true;
     this.debug('destroy');
+
+    if (this.socket && !this.socket.destroyed) {
+      this.socket.destroy();
+    }
   }
 
   get isAvailable() {
@@ -92,12 +91,11 @@ class Transport extends Obfuscated {
       this.socket.destroy();
     }
 
-    if (this.destroyed) {
-      this.socket.off('data', this.handleData);
-      this.socket.off('error', this.handleError);
-      this.socket.off('close', this.handleClose);
-    }
-    else {
+    this.socket.off('data', this.handleData);
+    this.socket.off('error', this.handleError);
+    this.socket.off('close', this.handleClose);
+    
+    if (!this.destroyed) {
       this.connect();
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -95,6 +95,14 @@ function makeMTProto(envMethods) {
       this.updates = new EventEmitter();
     }
 
+    destroy() {
+      for (const rpc of this.rpcs.values()) {
+        rpc.destroy()
+      }
+
+      this.rpcs.clear()
+    }
+
     async call(method, params = {}, options = {}) {
       const { syncAuth = true } = options;
 

--- a/src/index.js
+++ b/src/index.js
@@ -97,10 +97,10 @@ function makeMTProto(envMethods) {
 
     destroy() {
       for (const rpc of this.rpcs.values()) {
-        rpc.destroy()
+        rpc.destroy();
       }
 
-      this.rpcs.clear()
+      this.rpcs.clear();
     }
 
     async call(method, params = {}, options = {}) {

--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -32,9 +32,9 @@ class RPC {
     this.pendingAcks = [];
     this.messagesWaitAuth = [];
     this.messagesWaitResponse = new Map();
-    this.handleTransportOpen = this.handleTransportOpen.bind(this)
-    this.handleTransportError = this.handleTransportError.bind(this)
-    this.handleTransportMessage = this.handleTransportMessage.bind(this)
+    this.handleTransportOpen = this.handleTransportOpen.bind(this);
+    this.handleTransportError = this.handleTransportError.bind(this);
+    this.handleTransportMessage = this.handleTransportMessage.bind(this);
 
     this.updateSession();
 
@@ -63,12 +63,12 @@ class RPC {
 
   destroy() {
     this.debug('destroy rpc instance');
-    this.sendAcks.cancel()
-    this.transport.destroy()
+    this.sendAcks.cancel();
+    this.transport.destroy();
     this.transport.off('open', this.handleTransportOpen);
     this.transport.off('error', this.handleTransportError);
     this.transport.off('message', this.handleTransportMessage);
-    this.clearWaitMessages()
+    this.clearWaitMessages();
   }
 
   get isReady() {

--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -28,7 +28,6 @@ class RPC {
     this.debug = baseDebug.extend(`rpc-${this.dc.id}`);
     this.debug('init');
 
-    this.destroyed = false;
     this.isAuth = false;
     this.pendingAcks = [];
     this.messagesWaitAuth = [];
@@ -64,7 +63,6 @@ class RPC {
 
   destroy() {
     this.debug('destroy rpc instance');
-    this.destroyed = true
     this.sendAcks.cancel()
     this.transport.destroy()
     this.transport.off('open', this.handleTransportOpen);


### PR DESCRIPTION
Currently, after creating an instance of MTProto, there are no easy way to destroy instance (close open ws/socket connections and remove listeners). 

Here I added a `destroy` method. The usage is following:
```js
// 1. Create instance
const mtproto = new MTProto({ api_id, api_hash, storageOptions: {...}});

// 2. Call any method(-s)
mtproto.call('help.getNearestDc').then(result => ...});

// 3. Destroy: close open connections, reject pending requests, cleanup event's listeners
mtproto.destroy()
```