### PR TITLE
Fix undefined waitMessage

### DIFF
--- a/src/rpc/index.js
+++ b/src/rpc/index.js
@@ -546,10 +546,14 @@ class RPC {
 
       const waitMessage = this.messagesWaitResponse.get(message.req_msg_id);
 
-      if (message.result._ === 'mt_rpc_error') {
-        waitMessage.reject(message.result);
+      if (waitMessage) {
+        if (message.result._ === 'mt_rpc_error') {
+          waitMessage.reject(message.result);
+        } else {
+          waitMessage.resolve(message.result);
+        }
       } else {
-        waitMessage.resolve(message.result);
+        this.debug(`${message._} for a non-existent message`, message);
       }
 
       this.messagesWaitResponse.delete(message.req_msg_id);


### PR DESCRIPTION
I receive this error, then the process crash.

/Users/arron/project/local-service/viber/node_modules/@mtproto/core/src/rpc/index.js:550
        waitMessage.reject(message.result);
                    ^

TypeError: Cannot read properties of undefined (reading 'reject')